### PR TITLE
Fix OG data

### DIFF
--- a/src/components/Author.astro
+++ b/src/components/Author.astro
@@ -1,15 +1,9 @@
 ---
+import { parseMarkdownLink } from 'lib/utils';
+
 interface Props {
   authorString: string;
 }
-
-const parseMarkdownLink = (link: string) => {
-  const match = /\[(.+?)\]\((https?:\/\/[a-zA-Z0-9/.(-]+?)?\)/g.exec(link);
-  return {
-    author: match?.[1] || "Unknown",
-    avatarUrl: match?.[2] || "https://github.com/purduehackers.png",
-  };
-};
 
 const { authorString } = Astro.props;
 const { avatarUrl, author } = parseMarkdownLink(authorString);

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -33,6 +33,7 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={description} />
+<meta name="theme-color" content="#D97706" />
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -36,6 +36,7 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
 <meta name="theme-color" content="#D97706" />
 
 <!-- Open Graph / Facebook -->
+<meta property="og:site_name" content="Purdue Hackers" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={title} />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,6 +5,7 @@ import Header from "components/Header.astro";
 import Footer from "components/Footer.astro";
 
 import colors from "lib/colors";
+import { getOgImage } from "lib/utils";
 
 type Props = CollectionEntry<"blog">["data"];
 
@@ -16,11 +17,13 @@ const {
   authors,
   color = colors[0],
 } = Astro.props;
+
+const ogImage = getOgImage({ title: title, authors })
 ---
 
 <html lang="en">
   <head>
-    <BaseHead title={`${title} | Purdue Hackers`} description={description} />
+    <BaseHead title={`${title} | Purdue Hackers`} description={description} image={ogImage} />
   </head>
 
   <main

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,24 @@
+export const parseMarkdownLink = (link: string) => {
+  const match = /\[(.+?)\]\((https?:\/\/[a-zA-Z0-9/.(-]+?)?\)/g.exec(link);
+  return {
+    author: match?.[1] || "Unknown",
+    avatarUrl: match?.[2] || "https://github.com/purduehackers.png",
+  };
+};
+
+export const getOgImage = ({
+  title,
+  authors,
+}: {
+  title: string;
+  authors: string[];
+}) => {
+  let authorImages = "";
+  for (const author of authors) {
+    const { avatarUrl } = parseMarkdownLink(author);
+    authorImages += `&images=${encodeURIComponent(avatarUrl)}`;
+  }
+  return `https://og.purduehackers.com/${encodeURIComponent(
+    title,
+  )}.png?theme=light&md=1&fontSize=200px&caption=${authorImages}`;
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ const posts = coll
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} image="https://og.purduehackers.com/Blog.png?theme=light&md=1&fontSize=250px&caption=" />
   </head>
   <body>
     <div class="min-h-screen flex flex-col">


### PR DESCRIPTION
Some OG data was lost during the transition to Astro, including no OG images. This PR adds them back to match where they were before.