### PR TITLE
Fix rss.xml to have parity with old-nextjs branch

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -23,9 +23,9 @@ export const GET: APIRoute = async ({ site }) => {
     description: SITE_DESCRIPTION,
     site: site!,
     customData:
-      `<lastBuildDate>` + sorted_posts[0]!.data.pubDate.toUTCString() + `</lastBuildDate>` +
-      `<atom:link href="` + site_url + `rss.xml" rel="self" type="application/rss+xml"/>` +
-      `<pubDate>` + sorted_posts[0]!.data.pubDate.toUTCString() + `</pubDate>`,
+      `<lastBuildDate>${sorted_posts[0]!.data.pubDate.toUTCString()}</lastBuildDate>` +
+      `<atom:link href="${site_url}rss.xml" rel="self" type="application/rss+xml"/>` +
+      `<pubDate>${sorted_posts[0]!.data.pubDate.toUTCString()}</pubDate>`,
     items: sorted_posts.map((post) => ({
       ...post.data,
       link: `/blog/${post.slug}/`,

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -23,9 +23,9 @@ export const GET: APIRoute = async ({ site }) => {
     description: SITE_DESCRIPTION,
     site: site!,
     customData:
-      `<lastBuildDate>` + sorted_posts[0].data.pubDate.toUTCString() + `</lastBuildDate>` +
+      `<lastBuildDate>` + sorted_posts[0]!.data.pubDate.toUTCString() + `</lastBuildDate>` +
       `<atom:link href="` + site_url + `rss.xml" rel="self" type="application/rss+xml"/>` +
-      `<pubDate>` + sorted_posts[0].data.pubDate.toUTCString() + `</pubDate>`,
+      `<pubDate>` + sorted_posts[0]!.data.pubDate.toUTCString() + `</pubDate>`,
     items: sorted_posts.map((post) => ({
       ...post.data,
       link: `/blog/${post.slug}/`,

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -9,7 +9,7 @@ export const GET: APIRoute = async ({ site }) => {
   const sorted_posts = posts.sort((a, b) => Number(b.data.pubDate) - Number(a.data.pubDate))
 
   const site_url =
-  process.env.NODE_ENV === 'production'
+  process.env.PUBLIC_VERCEL_ENV === 'production'
     ? 'https://blog.purduehackers.com/'
     : 'http://localhost:3000/'
 

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -5,11 +5,28 @@ import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 
 export const GET: APIRoute = async ({ site }) => {
   const posts = await getCollection("blog");
+
+  const sorted_posts = posts.sort((a, b) => Number(b.data.pubDate) - Number(a.data.pubDate))
+
+  const site_url =
+  process.env.NODE_ENV === 'production'
+    ? 'https://blog.purduehackers.com/'
+    : 'http://localhost:3000/'
+
   return rss({
+    xmlns: {
+      dc: `http://purl.org/dc/elements/1.1/`,
+      content: `http://purl.org/rss/1.0/modules/content/`,
+      atom: `http://www.w3.org/2005/Atom`
+    },
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: site!,
-    items: posts.map((post) => ({
+    customData:
+      `<lastBuildDate>` + sorted_posts[0].data.pubDate.toUTCString() + `</lastBuildDate>` +
+      `<atom:link href="` + site_url + `rss.xml" rel="self" type="application/rss+xml"/>` +
+      `<pubDate>` + sorted_posts[0].data.pubDate.toUTCString() + `</pubDate>`,
+    items: sorted_posts.map((post) => ({
       ...post.data,
       link: `/blog/${post.slug}/`,
     })),


### PR DESCRIPTION
This should fix RSS and Atom support by matching parity with the previous rss.xml.

Changes:
 - Add `pubDate` and `lastBuildDate` fields to root
 - Add `atom:link` self reference to root
 - Order posts by `pubDate` with newest first
 - Add xmlns namespaces `dc`, `content`, and `atom`
 
 Breaks in Parity:
 - Title and Description fields are not encapsulated in CDATA tags (Astro RSS seems to handle things without them fine)
 - Some fields on each blog item are out of order; This should not affect parsing